### PR TITLE
fix: don't `stringify` eslint plugins to avoid erroring if they are circular

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -89,29 +89,8 @@ function parseFoldersToGlobs(patterns, extensions = []) {
   });
 }
 
-/**
- * @param {string} _ key, but unused
- * @param {any} value
- */
-const jsonStringifyReplacerSortKeys = (_, value) => {
-  /**
-   * @param {{ [x: string]: any; }} sorted
-   * @param {string | number} key
-   */
-  const insert = (sorted, key) => {
-    // eslint-disable-next-line no-param-reassign
-    sorted[key] = value[key];
-    return sorted;
-  };
-
-  return value instanceof Object && !(value instanceof Array)
-    ? Object.keys(value).sort().reduce(insert, {})
-    : value;
-};
-
 module.exports = {
   arrify,
   parseFiles,
   parseFoldersToGlobs,
-  jsonStringifyReplacerSortKeys,
 };

--- a/test/circular-plugin.test.js
+++ b/test/circular-plugin.test.js
@@ -1,0 +1,34 @@
+import pack from './utils/pack';
+
+describe('circular plugin', () => {
+  it('should support plugins with circular configs', async () => {
+    const plugin = {
+      configs: {},
+      rules: {},
+      processors: {},
+    };
+
+    Object.assign(plugin.configs, {
+      recommended: {
+        plugins: {
+          self: plugin,
+        },
+        rules: {},
+      },
+    });
+
+    const loaderOptions = {
+      configType: 'flat',
+      overrideConfig: {
+        plugins: { plugin: plugin },
+      },
+      overrideConfigFile: true,
+    };
+
+    const compiler = pack('good', loaderOptions);
+
+    const stats = await compiler.runAsync();
+    expect(stats.hasWarnings()).toBe(false);
+    expect(stats.hasErrors()).toBe(false);
+  });
+});


### PR DESCRIPTION
Replaces the `getESLint.js` cache object with a `Map`, and uses ESLint plugin objects directly as keys instead of converting them to JSON, thus preventing an error when said plugins contain circular references.